### PR TITLE
[FIXED]fix_public_sign_in

### DIFF
--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -18,11 +18,15 @@ class Public::SessionsController < Devise::SessionsController
   #   super
   # end
 
+
+  # protected
   def after_sign_in_path_for(resource)
     public_root_path
   end
-  # protected
-
+  
+  def after_sign_out_path_for(resource)
+    public_root_path
+  end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])


### PR DESCRIPTION
サインアウト後の遷移先をroot(top)に指定した。(挙動としては変化なし)
サインイン後の遷移先についての記述をプライベートに移動した。